### PR TITLE
Add skeleton for GitHub license checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-README.md
+# Boilerplate GitHub License Checker
+
+This repository contains a skeleton Python application that fetches license information from a given GitHub repository URL. The code is intentionally minimal so you can extend it or ask another language model to build the final implementation.
+
+## Purpose
+
+The goal is to provide a starting point for an application that:
+1. Accepts a GitHub repository URL or `owner/repo` string as input.
+2. Retrieves the repository's license details using the GitHub API.
+3. Displays the license name and a brief description of what the license permits.
+
+## How to Build the Final Application
+
+1. Install the required Python dependencies from `requirements.txt`.
+2. Implement the functions marked with `TODO` comments in `src/main.py`.
+3. Run the application using `python -m src.main <github_url>`.
+
+See inline comments in the code for more details about each step.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.0
+# Optionally add PyGithub if you want a higher-level API wrapper
+# PyGithub>=1.59

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,100 @@
+"""Skeleton module for fetching GitHub license information.
+
+This template provides placeholders for implementing a simple command-line
+application. The final code should:
+    1. Parse a GitHub repository URL or "owner/repo" string from the command
+       line.
+    2. Query the GitHub REST API to obtain the repository's license details.
+    3. Print the license name along with a short description of what the license
+       allows.
+
+You can extend this file by filling in the "TODO" sections with real code.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+
+# TODO: If you prefer, install the PyGithub package and use its API wrapper
+# instead of raw HTTP requests via 'requests'. For the template, we keep things
+# simple and leave the choice up to the implementer.
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns
+    -------
+    argparse.Namespace
+        The parsed arguments with the attribute ``repo`` containing the
+        GitHub repository URL or ``owner/repo`` string.
+    """
+
+    parser = argparse.ArgumentParser(description="Fetch GitHub repository license")
+    parser.add_argument("repo", help="GitHub URL or 'owner/repo' string")
+    return parser.parse_args()
+
+
+def fetch_license_info(repo: str) -> Optional["LicenseInfo"]:
+    """Fetch license information from the GitHub API.
+
+    Parameters
+    ----------
+    repo : str
+        Repository URL or ``owner/repo`` string.
+
+    Returns
+    -------
+    Optional[LicenseInfo]
+        Structured license data or ``None`` if the request fails.
+    """
+    # TODO: Use the GitHub API to request license details. You can either use
+    # the endpoint ``GET /repos/{owner}/{repo}/license`` or rely on the PyGithub
+    # library's helper methods.
+    # - Handle HTTP errors (e.g., repository not found, rate limiting).
+    # - Parse the JSON response and populate a ``LicenseInfo`` instance.
+    raise NotImplementedError
+
+
+@dataclass
+class LicenseInfo:
+    """Simple data container for license details."""
+
+    spdx_id: str
+    name: str
+    description: str  # short explanation of what the license allows
+
+
+def describe_license(spdx_id: str) -> str:
+    """Return a short, human-readable description of a license.
+
+    This function can be implemented as a mapping from SPDX identifiers
+    to a one-paragraph summary describing permissions, conditions, and
+    limitations. For uncommon licenses, you might fetch the text and use
+    an LLM to summarize it.
+    """
+    # TODO: Provide summaries for common licenses (MIT, Apache-2.0, GPL-3.0, ...).
+    # Optionally integrate an LLM for unknown licenses.
+    raise NotImplementedError
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Normalize the repository string or URL here if needed.
+    # TODO: Parse the input to extract ``owner`` and ``repo`` parts.
+
+    license_info = fetch_license_info(args.repo)
+    if not license_info:
+        print("Failed to retrieve license information")
+        return
+
+    print(f"License: {license_info.name} ({license_info.spdx_id})")
+    print()
+    print(license_info.description)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace placeholder README with description and build instructions
- add requirements.txt for dependencies
- create `src/main.py` with TODOs for fetching license info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e96a2d18083318a255f79ebe4f94e