### PR TITLE
Add AI Terms Analyzer web app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEBIUS_API_KEY=your-nebius-token-factory-key-here
+NEBIUS_BASE_URL=https://api.studio.nebius.com/v1
+NEBIUS_MODEL=meta-llama/Meta-Llama-3.1-70B-Instruct

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.env
+__pycache__/
+*.pyc
+.venv/
+venv/
+*.egg-info/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,54 @@
-# Boilerplate GitHub License Checker
+# AI Terms Analyzer ⚡
 
-This repository contains a skeleton Python application that fetches license information from a given GitHub repository URL. The code is intentionally minimal so you can extend it or ask another language model to build the final implementation.
+A web application that interrogates the Terms & Conditions of generative AI platforms and produces a structured verdict report.
 
-## Purpose
+## What it does
 
-The goal is to provide a starting point for an application that:
-1. Accepts a GitHub repository URL or `owner/repo` string as input.
-2. Retrieves the repository's license details using the GitHub API.
-3. Displays the license name and a brief description of what the license permits.
+Paste a URL to any GenAI platform's Terms of Service (or paste the text directly) and the analyzer will:
 
-## How to Build the Final Application
+- **Fetch & extract** the T&C text from the page
+- **Cross-check** against key categories:
+  - Training on user content
+  - Ownership of outputs
+  - Enterprise exclusions
+  - Data retention policy
+  - Third-party sharing
+  - Content restrictions
+  - Liability limitation
+  - IP indemnification
+- **Classify** the platform as Restrictive / Moderate / Permissive / Unclear
+- **Output** a risk score, detailed verdict, quick checklist, key quotes, and recommendations
 
-1. Install the required Python dependencies from `requirements.txt`.
-2. Implement the functions marked with `TODO` comments in `src/main.py`.
-3. Run the application using `python -m src.main <github_url>`.
+## Setup
 
-See inline comments in the code for more details about each step.
+```bash
+pip install -r requirements.txt
+```
+
+Create a `.env` file (see `.env.example`):
+
+```
+NEBIUS_API_KEY=your-nebius-token-factory-key
+NEBIUS_BASE_URL=https://api.studio.nebius.com/v1
+NEBIUS_MODEL=meta-llama/Meta-Llama-3.1-70B-Instruct
+```
+
+## Run
+
+```bash
+python app.py
+```
+
+Then open http://localhost:5000 in your browser.
+
+## Tests
+
+```bash
+python -m pytest tests/ -v
+```
+
+## Tech Stack
+
+- **Backend**: Flask + OpenAI-compatible client (Nebius AI)
+- **Frontend**: Single-page HTML/CSS/JS with dark theme
+- **Extraction**: Trafilatura + BeautifulSoup fallback

--- a/app.py
+++ b/app.py
@@ -1,0 +1,192 @@
+"""AI Terms & Conditions Analyzer - Flask Application."""
+
+import json
+import os
+import re
+
+import requests
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+from flask import Flask, jsonify, render_template, request
+from openai import OpenAI
+
+load_dotenv()
+
+app = Flask(__name__)
+
+# ---------------------------------------------------------------------------
+# Nebius / OpenAI-compatible client
+# ---------------------------------------------------------------------------
+client = OpenAI(
+    api_key=os.getenv("NEBIUS_API_KEY", ""),
+    base_url=os.getenv("NEBIUS_BASE_URL", "https://api.studio.nebius.com/v1"),
+)
+MODEL = os.getenv("NEBIUS_MODEL", "meta-llama/Meta-Llama-3.1-70B-Instruct")
+
+# ---------------------------------------------------------------------------
+# T&C text extraction
+# ---------------------------------------------------------------------------
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+
+def fetch_terms_text(url: str) -> str:
+    """Fetch a URL and extract the main text content."""
+    try:
+        import trafilatura
+
+        downloaded = trafilatura.fetch_url(url)
+        if downloaded:
+            text = trafilatura.extract(downloaded, include_comments=False,
+                                       include_tables=True)
+            if text and len(text) > 200:
+                return text[:15000]
+    except Exception:
+        pass
+
+    # Fallback: requests + BeautifulSoup
+    resp = requests.get(url, headers=HEADERS, timeout=20)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    for tag in soup(["script", "style", "nav", "footer", "header", "aside"]):
+        tag.decompose()
+
+    text = soup.get_text(separator="\n", strip=True)
+    # Collapse whitespace
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text[:15000]
+
+
+# ---------------------------------------------------------------------------
+# AI analysis
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT = """\
+You are an expert AI-policy analyst. The user will give you the Terms & Conditions \
+(or Terms of Service / Acceptable Use Policy) text from a generative-AI platform.
+
+Analyse the text and return a JSON object with EXACTLY this schema (no markdown, \
+no code fences, pure JSON):
+
+{
+  "platform_name": "<detected platform name>",
+  "classification": "<one of: Restrictive | Moderate | Permissive | Unclear>",
+  "overall_verdict": "<1-2 sentence plain-english verdict>",
+  "risk_score": <integer 1-10, 10 = highest risk to users>,
+  "categories": {
+    "training_on_user_content": {
+      "status": "<Yes | No | Opt-out | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "ownership_of_outputs": {
+      "status": "<User | Platform | Shared | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "enterprise_exclusions": {
+      "status": "<Yes | No | Partial | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "data_retention": {
+      "status": "<Retained | Deleted | Configurable | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "third_party_sharing": {
+      "status": "<Yes | No | Anonymised | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "content_restrictions": {
+      "status": "<Strict | Moderate | Minimal | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "liability_limitation": {
+      "status": "<Strong | Moderate | Weak | Unclear>",
+      "detail": "<short explanation>"
+    },
+    "ip_indemnification": {
+      "status": "<Yes | No | Partial | Unclear>",
+      "detail": "<short explanation>"
+    }
+  },
+  "checklist": [
+    {"item": "<short checklist item>", "pass": <true|false|null>}
+  ],
+  "key_quotes": ["<relevant verbatim quote from T&Cs>", "..."],
+  "recommendations": ["<actionable recommendation>", "..."]
+}
+
+Rules:
+- checklist should have 6-10 items covering the most important rights & risks.
+- pass=true means favourable for the user, false means unfavourable, null means unclear.
+- key_quotes: pick 2-4 of the most impactful verbatim sentences.
+- recommendations: 2-4 practical next-steps for the user.
+- If the text doesn't look like T&Cs, set classification to "Unclear" and explain in overall_verdict.
+"""
+
+
+def analyse_terms(terms_text: str) -> dict:
+    """Send terms text to the LLM and return structured analysis."""
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": terms_text},
+        ],
+        temperature=0.2,
+        max_tokens=3000,
+    )
+    raw = response.choices[0].message.content.strip()
+
+    # Strip markdown code fences if present
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```$", "", raw)
+
+    return json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/analyse", methods=["POST"])
+def api_analyse():
+    data = request.get_json(force=True)
+    url = data.get("url", "").strip()
+    raw_text = data.get("raw_text", "").strip()
+
+    if not url and not raw_text:
+        return jsonify({"error": "Provide a URL or paste the T&C text."}), 400
+
+    try:
+        if url:
+            terms_text = fetch_terms_text(url)
+        else:
+            terms_text = raw_text[:15000]
+
+        if len(terms_text) < 100:
+            return jsonify({"error": "Could not extract enough text. Try pasting the T&Cs directly."}), 400
+
+        result = analyse_terms(terms_text)
+        result["source_url"] = url or "pasted text"
+        result["text_length"] = len(terms_text)
+        return jsonify(result)
+
+    except json.JSONDecodeError:
+        return jsonify({"error": "AI returned invalid JSON. Please try again."}), 502
+    except requests.RequestException as e:
+        return jsonify({"error": f"Failed to fetch URL: {e}"}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 requests>=2.0
-# Optionally add PyGithub if you want a higher-level API wrapper
-# PyGithub>=1.59
+flask>=3.0
+openai>=1.0
+python-dotenv>=1.0
+beautifulsoup4>=4.12
+trafilatura>=1.6
+markupsafe>=2.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,428 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI Terms Analyzer</title>
+<style>
+/* ── Reset & Variables ─────────────────────────────────────── */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0a0a0f;--surface:#12121a;--surface2:#1a1a28;--surface3:#222236;
+  --border:#2a2a44;--text:#e0e0f0;--text2:#9090b0;--accent:#6c5ce7;
+  --accent2:#a29bfe;--green:#00e676;--red:#ff5252;--amber:#ffab40;
+  --cyan:#18ffff;--radius:12px;
+  --glow:0 0 30px rgba(108,92,231,.15);
+}
+html{font-size:16px}
+body{
+  font-family:'Segoe UI',system-ui,-apple-system,sans-serif;
+  background:var(--bg);color:var(--text);
+  min-height:100vh;line-height:1.6;
+}
+a{color:var(--accent2);text-decoration:none}
+
+/* ── Background grid effect ──────────────────────────────── */
+body::before{
+  content:'';position:fixed;inset:0;z-index:-1;
+  background-image:
+    linear-gradient(rgba(108,92,231,.03) 1px,transparent 1px),
+    linear-gradient(90deg,rgba(108,92,231,.03) 1px,transparent 1px);
+  background-size:60px 60px;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+.container{max-width:960px;margin:0 auto;padding:2rem 1.5rem}
+header{text-align:center;padding:3rem 0 2rem}
+header h1{
+  font-size:2.4rem;font-weight:800;
+  background:linear-gradient(135deg,var(--accent2),var(--cyan));
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  letter-spacing:-.02em;
+}
+header p{color:var(--text2);margin-top:.5rem;font-size:1.05rem}
+
+/* ── Card ────────────────────────────────────────────────── */
+.card{
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius);padding:1.75rem;margin-bottom:1.5rem;
+  box-shadow:var(--glow);
+}
+
+/* ── Input area ──────────────────────────────────────────── */
+.input-group{display:flex;gap:.75rem;flex-wrap:wrap}
+.input-group input[type=text]{
+  flex:1;min-width:200px;padding:.75rem 1rem;
+  background:var(--surface2);border:1px solid var(--border);
+  border-radius:8px;color:var(--text);font-size:.95rem;
+  transition:border-color .2s;
+}
+.input-group input:focus{outline:none;border-color:var(--accent)}
+textarea{
+  width:100%;min-height:120px;margin-top:.75rem;padding:.75rem 1rem;
+  background:var(--surface2);border:1px solid var(--border);
+  border-radius:8px;color:var(--text);font-size:.9rem;resize:vertical;
+  font-family:inherit;
+}
+textarea:focus{outline:none;border-color:var(--accent)}
+.or-divider{
+  text-align:center;color:var(--text2);font-size:.85rem;
+  margin:.75rem 0;text-transform:uppercase;letter-spacing:.1em;
+}
+
+/* ── Buttons ─────────────────────────────────────────────── */
+.btn{
+  padding:.75rem 1.5rem;border:none;border-radius:8px;
+  font-size:.95rem;font-weight:600;cursor:pointer;
+  transition:all .2s;display:inline-flex;align-items:center;gap:.5rem;
+}
+.btn-primary{
+  background:linear-gradient(135deg,var(--accent),#7c3aed);color:#fff;
+}
+.btn-primary:hover{filter:brightness(1.15);transform:translateY(-1px)}
+.btn-primary:disabled{opacity:.5;cursor:not-allowed;transform:none;filter:none}
+
+/* ── Loader ──────────────────────────────────────────────── */
+.loader{display:none;text-align:center;padding:2rem}
+.loader.active{display:block}
+.spinner{
+  width:48px;height:48px;border:3px solid var(--surface3);
+  border-top-color:var(--accent);border-radius:50%;
+  animation:spin .8s linear infinite;margin:0 auto 1rem;
+}
+@keyframes spin{to{transform:rotate(360deg)}}
+.loader p{color:var(--text2);font-size:.9rem}
+
+/* ── Error ───────────────────────────────────────────────── */
+.error-msg{
+  background:rgba(255,82,82,.1);border:1px solid rgba(255,82,82,.3);
+  color:var(--red);padding:1rem;border-radius:8px;margin-top:1rem;
+  display:none;
+}
+.error-msg.active{display:block}
+
+/* ── Results ─────────────────────────────────────────────── */
+#results{display:none}
+#results.active{display:block}
+
+/* Verdict banner */
+.verdict-banner{
+  padding:1.5rem;border-radius:var(--radius);margin-bottom:1.5rem;
+  border:1px solid var(--border);position:relative;overflow:hidden;
+}
+.verdict-banner::before{
+  content:'';position:absolute;inset:0;opacity:.08;
+  background:linear-gradient(135deg,var(--accent),var(--cyan));
+}
+.verdict-banner h2{font-size:1.1rem;color:var(--text2);font-weight:500;margin-bottom:.25rem}
+.verdict-banner .platform{font-size:1.6rem;font-weight:700;margin-bottom:.5rem}
+.verdict-banner .verdict-text{font-size:1.05rem;line-height:1.5}
+
+/* Classification badge */
+.badge{
+  display:inline-block;padding:.3rem .9rem;border-radius:20px;
+  font-size:.8rem;font-weight:700;text-transform:uppercase;letter-spacing:.05em;
+}
+.badge-restrictive{background:rgba(255,82,82,.15);color:var(--red);border:1px solid rgba(255,82,82,.3)}
+.badge-moderate{background:rgba(255,171,64,.15);color:var(--amber);border:1px solid rgba(255,171,64,.3)}
+.badge-permissive{background:rgba(0,230,118,.15);color:var(--green);border:1px solid rgba(0,230,118,.3)}
+.badge-unclear{background:rgba(144,144,176,.15);color:var(--text2);border:1px solid rgba(144,144,176,.3)}
+
+/* Risk meter */
+.risk-meter{margin:1rem 0}
+.risk-meter label{font-size:.85rem;color:var(--text2);display:block;margin-bottom:.4rem}
+.risk-bar-track{
+  height:8px;background:var(--surface3);border-radius:4px;overflow:hidden;
+}
+.risk-bar-fill{
+  height:100%;border-radius:4px;transition:width .6s ease;
+  background:linear-gradient(90deg,var(--green),var(--amber),var(--red));
+}
+.risk-value{font-size:.85rem;color:var(--text2);margin-top:.25rem;text-align:right}
+
+/* Category grid */
+.cat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem;margin-top:1rem}
+.cat-card{
+  background:var(--surface2);border:1px solid var(--border);
+  border-radius:10px;padding:1.1rem;transition:border-color .2s;
+}
+.cat-card:hover{border-color:var(--accent)}
+.cat-card h4{font-size:.85rem;text-transform:uppercase;letter-spacing:.06em;color:var(--text2);margin-bottom:.4rem}
+.cat-card .status{font-weight:700;font-size:1rem;margin-bottom:.3rem}
+.cat-card .detail{font-size:.85rem;color:var(--text2);line-height:1.45}
+
+/* Status colours */
+.s-good{color:var(--green)}.s-bad{color:var(--red)}.s-warn{color:var(--amber)}.s-neutral{color:var(--text2)}
+
+/* Checklist */
+.checklist{list-style:none;margin-top:.75rem}
+.checklist li{
+  padding:.6rem .75rem;border-bottom:1px solid var(--border);
+  display:flex;align-items:center;gap:.6rem;font-size:.92rem;
+}
+.checklist li:last-child{border-bottom:none}
+.check-icon{font-size:1.1rem;flex-shrink:0}
+
+/* Quotes */
+.quote{
+  border-left:3px solid var(--accent);padding:.5rem 1rem;
+  margin:.5rem 0;color:var(--text2);font-style:italic;font-size:.9rem;
+  background:var(--surface2);border-radius:0 8px 8px 0;
+}
+
+/* Recommendations */
+.rec-list{list-style:none;margin-top:.5rem}
+.rec-list li{
+  padding:.4rem 0;padding-left:1.2rem;position:relative;
+  font-size:.92rem;color:var(--text);
+}
+.rec-list li::before{
+  content:'→';position:absolute;left:0;color:var(--accent2);
+}
+
+/* Footer */
+footer{text-align:center;padding:2rem 0;color:var(--text2);font-size:.8rem}
+</style>
+</head>
+<body>
+
+<div class="container">
+  <header>
+    <h1>⚡ AI Terms Analyzer</h1>
+    <p>Interrogate any GenAI platform's Terms & Conditions — instantly.</p>
+  </header>
+
+  <!-- Input -->
+  <div class="card" id="input-card">
+    <div class="input-group">
+      <input type="text" id="url-input" placeholder="Paste a T&Cs / ToS URL (e.g. https://openai.com/policies/terms-of-use)">
+      <button class="btn btn-primary" id="analyse-btn" onclick="runAnalysis()">
+        <span id="btn-label">Analyse</span>
+      </button>
+    </div>
+    <div class="or-divider">— or paste the text directly —</div>
+    <textarea id="text-input" placeholder="Paste Terms & Conditions text here…"></textarea>
+  </div>
+
+  <!-- Loader -->
+  <div class="loader" id="loader">
+    <div class="spinner"></div>
+    <p>Fetching &amp; analysing terms… this takes 15-30 seconds.</p>
+  </div>
+
+  <!-- Error -->
+  <div class="error-msg" id="error-msg"></div>
+
+  <!-- Results -->
+  <div id="results">
+    <!-- Verdict Banner -->
+    <div class="verdict-banner card">
+      <h2>Platform</h2>
+      <div class="platform" id="r-platform"></div>
+      <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:.75rem">
+        <span id="r-badge" class="badge"></span>
+        <span style="color:var(--text2);font-size:.85rem" id="r-source"></span>
+      </div>
+      <div class="verdict-text" id="r-verdict"></div>
+      <div class="risk-meter">
+        <label>User Risk Score</label>
+        <div class="risk-bar-track"><div class="risk-bar-fill" id="r-risk-bar"></div></div>
+        <div class="risk-value" id="r-risk-value"></div>
+      </div>
+    </div>
+
+    <!-- Categories -->
+    <div class="card">
+      <h3 style="margin-bottom:.25rem">📋 Detailed Breakdown</h3>
+      <p style="color:var(--text2);font-size:.85rem;margin-bottom:.5rem">How this platform handles your content and rights.</p>
+      <div class="cat-grid" id="r-categories"></div>
+    </div>
+
+    <!-- Checklist -->
+    <div class="card">
+      <h3>✅ Quick Checklist</h3>
+      <ul class="checklist" id="r-checklist"></ul>
+    </div>
+
+    <!-- Key Quotes -->
+    <div class="card">
+      <h3 style="margin-bottom:.75rem">💬 Key Quotes from T&Cs</h3>
+      <div id="r-quotes"></div>
+    </div>
+
+    <!-- Recommendations -->
+    <div class="card">
+      <h3 style="margin-bottom:.5rem">🎯 Recommendations</h3>
+      <ul class="rec-list" id="r-recs"></ul>
+    </div>
+  </div>
+
+  <footer>AI Terms Analyzer &middot; Powered by Nebius AI</footer>
+</div>
+
+<script>
+const CATEGORY_LABELS = {
+  training_on_user_content: "Training on Your Content",
+  ownership_of_outputs: "Ownership of Outputs",
+  enterprise_exclusions: "Enterprise Exclusions",
+  data_retention: "Data Retention",
+  third_party_sharing: "Third-Party Sharing",
+  content_restrictions: "Content Restrictions",
+  liability_limitation: "Liability Limitation",
+  ip_indemnification: "IP Indemnification",
+};
+
+const GOOD_STATUSES = new Set([
+  "No","User","Deleted","Yes","Minimal","Weak","Opt-out","Configurable","Anonymised"
+]);
+const BAD_STATUSES = new Set([
+  "Yes","Platform","Retained","Strict","Strong"
+]);
+
+function statusClass(category, status) {
+  // Context-dependent: "Yes" is good for enterprise_exclusions/ip_indemnification but bad for training
+  const goodWhenYes = new Set(["enterprise_exclusions","ip_indemnification"]);
+  const s = status.trim();
+  if (s === "Unclear") return "s-neutral";
+  if (s === "Yes" && goodWhenYes.has(category)) return "s-good";
+  if (s === "No" && goodWhenYes.has(category)) return "s-bad";
+  // training_on_user_content
+  if (category === "training_on_user_content") {
+    if (s === "No") return "s-good";
+    if (s === "Yes") return "s-bad";
+    return "s-warn";
+  }
+  if (category === "ownership_of_outputs") {
+    if (s === "User") return "s-good";
+    if (s === "Platform") return "s-bad";
+    return "s-warn";
+  }
+  if (category === "data_retention") {
+    if (s === "Deleted" || s === "Configurable") return "s-good";
+    if (s === "Retained") return "s-bad";
+    return "s-warn";
+  }
+  if (category === "third_party_sharing") {
+    if (s === "No" || s === "Anonymised") return "s-good";
+    if (s === "Yes") return "s-bad";
+    return "s-warn";
+  }
+  if (category === "content_restrictions") {
+    if (s === "Minimal") return "s-good";
+    if (s === "Strict") return "s-bad";
+    return "s-warn";
+  }
+  if (category === "liability_limitation") {
+    if (s === "Weak") return "s-good";
+    if (s === "Strong") return "s-bad";
+    return "s-warn";
+  }
+  return "s-neutral";
+}
+
+function classificationBadge(cls) {
+  const c = (cls || "unclear").toLowerCase();
+  return `badge-${c}`;
+}
+
+function renderResults(data) {
+  document.getElementById("r-platform").textContent = data.platform_name || "Unknown";
+  document.getElementById("r-verdict").textContent = data.overall_verdict || "";
+
+  const badge = document.getElementById("r-badge");
+  badge.textContent = data.classification || "Unclear";
+  badge.className = "badge " + classificationBadge(data.classification);
+
+  document.getElementById("r-source").textContent = data.source_url ? `Source: ${data.source_url}` : "";
+
+  // Risk
+  const risk = data.risk_score || 0;
+  document.getElementById("r-risk-bar").style.width = `${risk * 10}%`;
+  document.getElementById("r-risk-value").textContent = `${risk} / 10`;
+
+  // Categories
+  const catGrid = document.getElementById("r-categories");
+  catGrid.innerHTML = "";
+  if (data.categories) {
+    for (const [key, val] of Object.entries(data.categories)) {
+      const cls = statusClass(key, val.status || "Unclear");
+      catGrid.innerHTML += `
+        <div class="cat-card">
+          <h4>${CATEGORY_LABELS[key] || key}</h4>
+          <div class="status ${cls}">${val.status}</div>
+          <div class="detail">${val.detail}</div>
+        </div>`;
+    }
+  }
+
+  // Checklist
+  const cl = document.getElementById("r-checklist");
+  cl.innerHTML = "";
+  (data.checklist || []).forEach(item => {
+    const icon = item.pass === true ? "✅" : item.pass === false ? "❌" : "❓";
+    cl.innerHTML += `<li><span class="check-icon">${icon}</span>${item.item}</li>`;
+  });
+
+  // Quotes
+  const qd = document.getElementById("r-quotes");
+  qd.innerHTML = "";
+  (data.key_quotes || []).forEach(q => {
+    qd.innerHTML += `<div class="quote">"${q}"</div>`;
+  });
+
+  // Recommendations
+  const rl = document.getElementById("r-recs");
+  rl.innerHTML = "";
+  (data.recommendations || []).forEach(r => {
+    rl.innerHTML += `<li>${r}</li>`;
+  });
+
+  document.getElementById("results").classList.add("active");
+}
+
+async function runAnalysis() {
+  const url = document.getElementById("url-input").value.trim();
+  const rawText = document.getElementById("text-input").value.trim();
+  const btn = document.getElementById("analyse-btn");
+  const loader = document.getElementById("loader");
+  const errorEl = document.getElementById("error-msg");
+  const results = document.getElementById("results");
+
+  if (!url && !rawText) {
+    errorEl.textContent = "Please enter a URL or paste T&C text.";
+    errorEl.classList.add("active");
+    return;
+  }
+
+  errorEl.classList.remove("active");
+  results.classList.remove("active");
+  loader.classList.add("active");
+  btn.disabled = true;
+
+  try {
+    const resp = await fetch("/api/analyse", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({url, raw_text: rawText}),
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+      throw new Error(data.error || "Analysis failed");
+    }
+    renderResults(data);
+  } catch (e) {
+    errorEl.textContent = e.message;
+    errorEl.classList.add("active");
+  } finally {
+    loader.classList.remove("active");
+    btn.disabled = false;
+  }
+}
+
+// Allow Enter on URL input
+document.getElementById("url-input").addEventListener("keydown", e => {
+  if (e.key === "Enter") runAnalysis();
+});
+</script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,89 @@
+"""Tests for the AI Terms Analyzer app."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app as analyzer_app
+
+
+@pytest.fixture
+def client():
+    analyzer_app.app.config["TESTING"] = True
+    with analyzer_app.app.test_client() as c:
+        yield c
+
+
+def test_index_returns_html(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"AI Terms Analyzer" in resp.data
+
+
+def test_analyse_missing_input(client):
+    resp = client.post("/api/analyse", json={})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+
+
+def test_analyse_short_text(client):
+    resp = client.post("/api/analyse", json={"raw_text": "short"})
+    assert resp.status_code == 400
+
+
+MOCK_AI_RESPONSE = json.dumps({
+    "platform_name": "TestAI",
+    "classification": "Moderate",
+    "overall_verdict": "This platform uses your data for training but offers opt-out.",
+    "risk_score": 5,
+    "categories": {
+        "training_on_user_content": {"status": "Opt-out", "detail": "Users can opt out."},
+        "ownership_of_outputs": {"status": "User", "detail": "Users own outputs."},
+        "enterprise_exclusions": {"status": "Yes", "detail": "Enterprise plans excluded."},
+        "data_retention": {"status": "Configurable", "detail": "Users can delete."},
+        "third_party_sharing": {"status": "Anonymised", "detail": "Only anonymised data shared."},
+        "content_restrictions": {"status": "Moderate", "detail": "Standard restrictions."},
+        "liability_limitation": {"status": "Strong", "detail": "Broad limitation clause."},
+        "ip_indemnification": {"status": "Partial", "detail": "Only for paid tiers."},
+    },
+    "checklist": [
+        {"item": "Data not used for training by default", "pass": False},
+        {"item": "User owns output", "pass": True},
+    ],
+    "key_quotes": ["We may use your content to improve our services."],
+    "recommendations": ["Enable the opt-out toggle in settings."],
+})
+
+
+@patch.object(analyzer_app, "client")
+def test_analyse_with_raw_text(mock_client, client):
+    mock_choice = MagicMock()
+    mock_choice.message.content = MOCK_AI_RESPONSE
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    long_text = "Terms and Conditions: " + "a " * 200
+    resp = client.post("/api/analyse", json={"raw_text": long_text})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["platform_name"] == "TestAI"
+    assert data["classification"] == "Moderate"
+    assert len(data["checklist"]) == 2
+
+
+@patch.object(analyzer_app, "fetch_terms_text", return_value="Terms " * 100)
+@patch.object(analyzer_app, "client")
+def test_analyse_with_url(mock_client, mock_fetch, client):
+    mock_choice = MagicMock()
+    mock_choice.message.content = MOCK_AI_RESPONSE
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    resp = client.post("/api/analyse", json={"url": "https://example.com/terms"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["source_url"] == "https://example.com/terms"


### PR DESCRIPTION
## Summary
- **New Flask web app** with a dark-themed UI that analyses GenAI platform Terms & Conditions
- Fetches T&C text from any URL (via Trafilatura + BeautifulSoup fallback) or accepts pasted text
- Sends extracted text to **Nebius AI** (OpenAI-compatible endpoint) for structured analysis
- Outputs a **verdict report** with: platform classification (Restrictive/Moderate/Permissive/Unclear), risk score (1-10), 8-category breakdown (training use, output ownership, enterprise exclusions, data retention, third-party sharing, content restrictions, liability, IP indemnification), quick checklist, key quotes, and actionable recommendations

## Files added/changed
- `app.py` — Flask backend with T&C fetching and AI analysis
- `templates/index.html` — Single-page dark UI with grid background, gradient accents, and animated results
- `requirements.txt` — Updated with Flask, OpenAI, dotenv, BS4, Trafilatura
- `.env.example` — Template for Nebius API credentials
- `.gitignore` — Standard Python ignores
- `tests/test_app.py` — 5 unit tests covering routes and AI response handling
- `README.md` — Updated project documentation

## Test plan
- [x] All 5 unit tests pass (`python -m pytest tests/ -v`)
- [ ] Manual test: paste a GenAI T&C URL and verify verdict renders
- [ ] Manual test: paste raw T&C text and verify analysis
- [ ] Verify `.env` with real Nebius API key connects successfully

https://claude.ai/code/session_01RdQHoQFCkKpYCFVfNTBb8V